### PR TITLE
fix: prevent flip crash on iPad Pro 11 and reduce preview glitch

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1756902493462</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/android/.project
+++ b/android/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1756902493462</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
- Added device-aware preset selection in switchCameras()
- Only fallback to a safe preset if the target device cannot support the current session preset
- Applied best compatible preset for requested aspect ratio (4K > 1080p > high for 16:9; photo > high for 4:3)
- Disabled preview layer animations/connection during reconfiguration to minimize tiny→large preview jump
- Normalized zoom after flip to account for iOS 18 display multiplier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive video quality selection that optimizes resolution based on device and aspect ratio for clearer previews.
* **Bug Fixes**
  * Smoother, faster camera switching with reduced flicker and UI glitches.
  * Preserves audio during camera swaps to avoid interruptions.
  * Maintains correct orientation and normalizes zoom after switching cameras.
* **Refactor**
  * Internal improvements to camera swap flow for greater stability and responsiveness.
* **Chores**
  * Project resource filtering added to streamline builds and reduce extraneous files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->