### PR TITLE
feat: add checkPermissions and requestPermissions methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Documentation for the [uploader](https://github.com/Cap-go/capacitor-uploader)
 * [`getAspectRatio()`](#getaspectratio)
 * [`setGridMode(...)`](#setgridmode)
 * [`getGridMode()`](#getgridmode)
+* [`checkPermissions(...)`](#checkpermissions)
+* [`requestPermissions(...)`](#requestpermissions)
 * [`getHorizontalFov()`](#gethorizontalfov)
 * [`getSupportedPictureSizes()`](#getsupportedpicturesizes)
 * [`setFlashMode(...)`](#setflashmode)
@@ -499,6 +501,46 @@ Gets the current grid mode of the camera preview overlay.
 **Returns:** <code>Promise&lt;{ gridMode: <a href="#gridmode">GridMode</a>; }&gt;</code>
 
 **Since:** 8.0.0
+
+--------------------
+
+
+### checkPermissions(...)
+
+```typescript
+checkPermissions(options?: Pick<PermissionRequestOptions, "disableAudio"> | undefined) => Promise<CameraPermissionStatus>
+```
+
+Checks the current camera (and optionally microphone) permission status without prompting the system dialog.
+
+| Param         | Type                                                                                                                          | Description                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#pick">Pick</a>&lt;<a href="#permissionrequestoptions">PermissionRequestOptions</a>, 'disableAudio'&gt;</code> | Set `disableAudio` to `false` to also include microphone status (defaults to `true`). |
+
+**Returns:** <code>Promise&lt;<a href="#camerapermissionstatus">CameraPermissionStatus</a>&gt;</code>
+
+**Since:** 8.7.0
+
+--------------------
+
+
+### requestPermissions(...)
+
+```typescript
+requestPermissions(options?: PermissionRequestOptions | undefined) => Promise<CameraPermissionStatus>
+```
+
+Requests camera (and optional microphone) permissions. If permissions are already granted or denied,
+the current status is returned without prompting. When `showSettingsAlert` is true and permissions are denied,
+a platform specific alert guiding the user to the app settings will be presented.
+
+| Param         | Type                                                                          | Description                                           |
+| ------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **`options`** | <code><a href="#permissionrequestoptions">PermissionRequestOptions</a></code> | - Configuration for the permission request behaviour. |
+
+**Returns:** <code>Promise&lt;<a href="#camerapermissionstatus">CameraPermissionStatus</a>&gt;</code>
+
+**Since:** 8.7.0
 
 --------------------
 
@@ -1050,6 +1092,26 @@ Defines the options for capturing a sample frame from the camera preview.
 | **`quality`** | <code>number</code> | The quality of the captured sample, from 0 to 100. | <code>85</code> |
 
 
+#### CameraPermissionStatus
+
+| Prop             | Type                                                        |
+| ---------------- | ----------------------------------------------------------- |
+| **`camera`**     | <code><a href="#permissionstate">PermissionState</a></code> |
+| **`microphone`** | <code><a href="#permissionstate">PermissionState</a></code> |
+
+
+#### PermissionRequestOptions
+
+| Prop                          | Type                 |
+| ----------------------------- | -------------------- |
+| **`disableAudio`**            | <code>boolean</code> |
+| **`showSettingsAlert`**       | <code>boolean</code> |
+| **`title`**                   | <code>string</code>  |
+| **`message`**                 | <code>string</code>  |
+| **`openSettingsButtonTitle`** | <code>string</code>  |
+| **`cancelButtonTitle`**       | <code>string</code>  |
+
+
 #### SupportedPictureSizes
 
 Represents the supported picture sizes for a camera facing a certain direction.
@@ -1168,6 +1230,18 @@ The available flash modes for the camera.
 'torch' is a continuous light mode.
 
 <code>"off" | "on" | "auto" | "torch"</code>
+
+
+#### PermissionState
+
+<code>'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'</code>
+
+
+#### Pick
+
+From T, pick a set of properties whose keys are in the union K
+
+<code>{ [P in K]: T[P]; }</code>
 
 
 #### FlashMode

--- a/README.md
+++ b/README.md
@@ -1094,10 +1094,10 @@ Defines the options for capturing a sample frame from the camera preview.
 
 #### CameraPermissionStatus
 
-| Prop             | Type                                                        |
-| ---------------- | ----------------------------------------------------------- |
-| **`camera`**     | <code><a href="#permissionstate">PermissionState</a></code> |
-| **`microphone`** | <code><a href="#permissionstate">PermissionState</a></code> |
+| Prop             | Type                                                        | Description                                                            |
+| ---------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **`camera`**     | <code><a href="#permissionstate">PermissionState</a></code> | Current camera permission status.                                      |
+| **`microphone`** | <code><a href="#permissionstate">PermissionState</a></code> | Optional - microphone permission status when audio capture is requested. |
 
 
 #### PermissionRequestOptions
@@ -1241,7 +1241,9 @@ The available flash modes for the camera.
 
 From T, pick a set of properties whose keys are in the union K
 
-<code>{ [P in K]: T[P]; }</code>
+<code>{
+ [P in K]: T[P];
+ }</code>
 
 
 #### FlashMode

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -67,7 +67,10 @@ import org.json.JSONObject;
       },
       alias = CameraPreview.CAMERA_WITH_LOCATION_PERMISSION_ALIAS
     ),
-    @Permission(strings = { RECORD_AUDIO }, alias = CameraPreview.MICROPHONE_ONLY_PERMISSION_ALIAS),
+    @Permission(
+      strings = { RECORD_AUDIO },
+      alias = CameraPreview.MICROPHONE_ONLY_PERMISSION_ALIAS
+    ),
   }
 )
 public class CameraPreview

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -773,26 +773,24 @@ public class CameraPreview
         return;
       }
 
-      AlertDialog dialog =
-        new AlertDialog.Builder(activity)
-          .setTitle(title)
-          .setMessage(message)
-          .setNegativeButton(cancelText, (d, which) -> {
-            d.dismiss();
-            isCameraPermissionDialogShowing = false;
-          })
-          .setPositiveButton(openSettingsText, (d, which) -> {
-            Intent intent = new Intent(
-              Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-            );
-            Uri uri =
-              Uri.fromParts("package", activity.getPackageName(), null);
-            intent.setData(uri);
-            activity.startActivity(intent);
-            isCameraPermissionDialogShowing = false;
-          })
-          .setOnDismissListener(d -> isCameraPermissionDialogShowing = false)
-          .create();
+      AlertDialog dialog = new AlertDialog.Builder(activity)
+        .setTitle(title)
+        .setMessage(message)
+        .setNegativeButton(cancelText, (d, which) -> {
+          d.dismiss();
+          isCameraPermissionDialogShowing = false;
+        })
+        .setPositiveButton(openSettingsText, (d, which) -> {
+          Intent intent = new Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+          );
+          Uri uri = Uri.fromParts("package", activity.getPackageName(), null);
+          intent.setData(uri);
+          activity.startActivity(intent);
+          isCameraPermissionDialogShowing = false;
+        })
+        .setOnDismissListener(d -> isCameraPermissionDialogShowing = false)
+        .create();
 
       isCameraPermissionDialogShowing = true;
       dialog.show();
@@ -812,10 +810,9 @@ public class CameraPreview
 
   @PluginMethod
   public void checkPermissions(PluginCall call) {
-    boolean disableAudio =
-      call.getBoolean("disableAudio") != null
-        ? Boolean.TRUE.equals(call.getBoolean("disableAudio"))
-        : true;
+    boolean disableAudio = call.getBoolean("disableAudio") != null
+      ? Boolean.TRUE.equals(call.getBoolean("disableAudio"))
+      : true;
 
     PermissionState cameraState = getPermissionState(
       CAMERA_ONLY_PERMISSION_ALIAS
@@ -847,11 +844,11 @@ public class CameraPreview
       ? CAMERA_ONLY_PERMISSION_ALIAS
       : CAMERA_WITH_AUDIO_PERMISSION_ALIAS;
 
-    boolean cameraGranted =
-      PermissionState.GRANTED.equals(
-        getPermissionState(CAMERA_ONLY_PERMISSION_ALIAS)
-      );
-    boolean audioGranted = disableAudio ||
+    boolean cameraGranted = PermissionState.GRANTED.equals(
+      getPermissionState(CAMERA_ONLY_PERMISSION_ALIAS)
+    );
+    boolean audioGranted =
+      disableAudio ||
       PermissionState.GRANTED.equals(
         getPermissionState(CAMERA_WITH_AUDIO_PERMISSION_ALIAS)
       );
@@ -881,19 +878,22 @@ public class CameraPreview
       : Boolean.TRUE.equals(disableAudioOption);
     this.lastDisableAudio = disableAudio;
 
-    PermissionState cameraState = getPermissionState(CAMERA_ONLY_PERMISSION_ALIAS);
+    PermissionState cameraState = getPermissionState(
+      CAMERA_ONLY_PERMISSION_ALIAS
+    );
     JSObject result = new JSObject();
     result.put("camera", mapPermissionState(cameraState));
 
     if (!disableAudio) {
-      PermissionState audioState = getPermissionState(CAMERA_WITH_AUDIO_PERMISSION_ALIAS);
+      PermissionState audioState = getPermissionState(
+        CAMERA_WITH_AUDIO_PERMISSION_ALIAS
+      );
       result.put("microphone", mapPermissionState(audioState));
     }
 
-    boolean showSettingsAlert =
-      call.getBoolean("showSettingsAlert") != null
-        ? Boolean.TRUE.equals(call.getBoolean("showSettingsAlert"))
-        : false;
+    boolean showSettingsAlert = call.getBoolean("showSettingsAlert") != null
+      ? Boolean.TRUE.equals(call.getBoolean("showSettingsAlert"))
+      : false;
 
     String cameraStateString = result.getString("camera");
     boolean cameraNeedsSettings =
@@ -919,12 +919,14 @@ public class CameraPreview
       }
 
       String title = call.getString("title", "Camera Permission Needed");
-      String message =
-        call.getString(
-          "message",
-          "Enable camera access in Settings to use the preview."
-        );
-      String openSettingsText = call.getString("openSettingsButtonTitle", "Open Settings");
+      String message = call.getString(
+        "message",
+        "Enable camera access in Settings to use the preview."
+      );
+      String openSettingsText = call.getString(
+        "openSettingsButtonTitle",
+        "Open Settings"
+      );
       String cancelText = call.getString(
         "cancelButtonTitle",
         activity.getString(android.R.string.cancel)

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -67,6 +67,7 @@ import org.json.JSONObject;
       },
       alias = CameraPreview.CAMERA_WITH_LOCATION_PERMISSION_ALIAS
     ),
+    @Permission(strings = { RECORD_AUDIO }, alias = CameraPreview.MICROPHONE_ONLY_PERMISSION_ALIAS),
   }
 )
 public class CameraPreview
@@ -114,6 +115,7 @@ public class CameraPreview
   static final String CAMERA_ONLY_PERMISSION_ALIAS = "cameraOnly";
   static final String CAMERA_WITH_LOCATION_PERMISSION_ALIAS =
     "cameraWithLocation";
+  static final String MICROPHONE_ONLY_PERMISSION_ALIAS = "microphoneOnly";
 
   private String captureCallbackId = "";
   private String sampleCallbackId = "";
@@ -826,7 +828,7 @@ public class CameraPreview
 
     if (!disableAudio) {
       PermissionState audioState = getPermissionState(
-        CAMERA_WITH_AUDIO_PERMISSION_ALIAS
+        MICROPHONE_ONLY_PERMISSION_ALIAS
       );
       result.put("microphone", mapPermissionState(audioState));
     }
@@ -853,7 +855,7 @@ public class CameraPreview
       );
     boolean audioGranted = disableAudio ||
       PermissionState.GRANTED.equals(
-        getPermissionState(CAMERA_WITH_AUDIO_PERMISSION_ALIAS)
+        getPermissionState(MICROPHONE_ONLY_PERMISSION_ALIAS)
       );
 
     if (cameraGranted && audioGranted) {

--- a/example-app/src/app/core/capacitor-camera-preview.service.ts
+++ b/example-app/src/app/core/capacitor-camera-preview.service.ts
@@ -10,6 +10,8 @@ import {
   CameraPreviewPlugin,
   GridMode,
   ExposureMode,
+  CameraPermissionStatus,
+  PermissionRequestOptions,
   getBase64FromFilePath,
   deleteFile,
 } from '@capgo/camera-preview';
@@ -68,6 +70,18 @@ export class CapacitorCameraViewService {
    */
   async isRunning(): Promise<boolean> {
     return (await this.#cameraView.isRunning()).isRunning;
+  }
+
+  async checkPermissions(options?: {
+    disableAudio?: boolean;
+  }): Promise<CameraPermissionStatus> {
+    return this.#cameraView.checkPermissions(options ?? {});
+  }
+
+  async requestPermissions(
+    options?: PermissionRequestOptions,
+  ): Promise<CameraPermissionStatus> {
+    return this.#cameraView.requestPermissions(options ?? {});
   }
 
   /**

--- a/example-app/src/app/pages/camera-view/camera-view.page.ts
+++ b/example-app/src/app/pages/camera-view/camera-view.page.ts
@@ -35,6 +35,7 @@ import {
 import {
   CameraDevice,
   CameraPosition,
+  CameraPermissionStatus,
   ExifData,
   FlashMode,
   PictureFormat,
@@ -275,12 +276,47 @@ export class CameraViewPage implements OnInit {
     // Validate that aspect ratio and size (width/height) are not both set
     const hasAspectRatio = this.aspectRatio() !== 'custom';
     const hasSize = this.previewWidth() > 0 || this.previewHeight() > 0;
-    
+
     if (hasAspectRatio && hasSize) {
-      const results = this.testResults() + 
+      const results = this.testResults() +
         `\n✗ Error: Cannot set both aspect ratio and size (width/height). Use setPreviewSize after start.`;
       this.testResults.set(results);
       return;
+    }
+
+    const disableAudio = this.disableAudio();
+    const needsSettings = (perm: CameraPermissionStatus): boolean => {
+      const cameraBlocked = perm.camera === 'denied' || perm.camera === 'prompt-with-rationale';
+      const microphoneBlocked = perm.microphone !== undefined &&
+        (perm.microphone === 'denied' || perm.microphone === 'prompt-with-rationale');
+      return cameraBlocked || microphoneBlocked;
+    };
+
+    let permissions = await this.#cameraViewService.checkPermissions({ disableAudio });
+
+    if (needsSettings(permissions)) {
+      const message = permissions.microphone && permissions.microphone !== 'granted'
+        ? 'Camera or microphone permission denied. Enable access in Settings and try again.'
+        : 'Camera permission denied. Enable access in Settings and try again.';
+      let results = this.testResults() +
+        `\n✗ ${message} (camera: ${permissions.camera}${permissions.microphone ? `, microphone: ${permissions.microphone}` : ''})`;
+
+      try {
+        const followUp = await this.#cameraViewService.requestPermissions({
+          disableAudio,
+          showSettingsAlert: true,
+        });
+        permissions = followUp;
+        results += `\n  (after requestPermissions → camera: ${followUp.camera}${followUp.microphone ? `, microphone: ${followUp.microphone}` : ''})`;
+      } catch (err) {
+        console.warn('Unable to open settings prompt', err);
+      }
+
+      this.testResults.set(results);
+
+      if (needsSettings(permissions)) {
+        return;
+      }
     }
 
     const cameraModal = await this.#modalController.create({
@@ -321,7 +357,29 @@ export class CameraViewPage implements OnInit {
       options?: any;
       type?: string;
       error?: string;
+      permissions?: CameraPermissionStatus;
     }>();
+
+    console.log('Camera modal dismissed', data);
+    if (data?.type === 'permissionDenied') {
+      const message = data.error || 'Camera permission denied. Enable access in Settings and try again.';
+      const details = data.permissions
+        ? ` (camera: ${data.permissions.camera}${data.permissions.microphone ? `, microphone: ${data.permissions.microphone}` : ''})`
+        : '';
+      let results = this.testResults() + `\n✗ ${message}${details}`;
+      try {
+        const followUp = await this.#cameraViewService.requestPermissions({
+          disableAudio: this.disableAudio(),
+          showSettingsAlert: true,
+        });
+        const followUpDetails = ` (after requestPermissions → camera: ${followUp.camera}${followUp.microphone ? `, microphone: ${followUp.microphone}` : ''})`;
+        results += `\n  ${followUpDetails}`;
+      } catch (err) {
+        console.warn('Unable to open settings prompt', err);
+      }
+      this.testResults.set(results);
+      return;
+    }
 
     if (data?.error) {
       // Show error in test results

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -5,6 +5,7 @@ import Capacitor
 import CoreImage
 import CoreLocation
 import MobileCoreServices
+import UIKit
 
 extension UIWindow {
     static var isLandscape: Bool {
@@ -66,6 +67,8 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         CAPPluginMethod(name: "deleteFile", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getOrientation", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSafeAreaInsets", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "checkPermissions", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "requestPermissions", returnType: CAPPluginReturnPromise),
         // Exposure control methods
         CAPPluginMethod(name: "getExposureModes", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getExposureMode", returnType: CAPPluginReturnPromise),
@@ -100,6 +103,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     private var positioning: String = "center"
     private var permissionCallID: String?
     private var waitingForLocation: Bool = false
+    private var isPresentingPermissionAlert: Bool = false
 
     // MARK: - Helper Methods for Aspect Ratio
 
@@ -162,6 +166,71 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             // Force a layout pass to apply changes
             webView.setNeedsLayout()
             webView.layoutIfNeeded()
+        }
+    }
+
+    private func presentCameraPermissionAlert(title: String,
+                                               message: String,
+                                               openSettingsText: String,
+                                               cancelText: String,
+                                               completion: (() -> Void)? = nil) {
+        DispatchQueue.main.async {
+            guard let viewController = self.bridge?.viewController else {
+                completion?()
+                return
+            }
+
+            if self.isPresentingPermissionAlert {
+                completion?()
+                return
+            }
+
+            let alert = UIAlertController(title: title,
+                                          message: message,
+                                          preferredStyle: .alert)
+
+            let cancelAction = UIAlertAction(title: cancelText, style: .cancel) { _ in
+                self.isPresentingPermissionAlert = false
+            }
+            alert.addAction(cancelAction)
+
+            let openSettingsAction = UIAlertAction(title: openSettingsText, style: .default) { _ in
+                self.isPresentingPermissionAlert = false
+                guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
+            }
+            alert.addAction(openSettingsAction)
+
+            self.isPresentingPermissionAlert = true
+            viewController.present(alert, animated: true) {
+                completion?()
+            }
+        }
+    }
+
+    private func mapAuthorizationStatus(_ status: AVAuthorizationStatus) -> String {
+        switch status {
+        case .authorized:
+            return "granted"
+        case .denied, .restricted:
+            return "denied"
+        case .notDetermined:
+            fallthrough
+        @unknown default:
+            return "prompt"
+        }
+    }
+
+    private func mapAudioPermission(_ permission: AVAudioSession.RecordPermission) -> String {
+        switch permission {
+        case .granted:
+            return "granted"
+        case .denied:
+            return "denied"
+        case .undetermined:
+            fallthrough
+        @unknown default:
+            return "prompt"
         }
     }
 
@@ -582,35 +651,62 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             call.reject("Cannot set both aspectRatio and size (width/height). Use setPreviewSize after start.")
             return
         }
-
-        AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
-
-            guard granted else {
-                call.reject("permission failed")
+        let beginStart: () -> Void = {
+            if self.cameraController.captureSession?.isRunning ?? false {
+                DispatchQueue.main.async {
+                    self.isInitializing = false
+                    call.reject("camera already started")
+                }
                 return
             }
 
-            if self.cameraController.captureSession?.isRunning ?? false {
-                call.reject("camera already started")
-            } else {
-                self.cameraController.prepare(cameraPosition: self.cameraPosition, deviceId: deviceId, disableAudio: self.disableAudio, cameraMode: cameraMode, aspectRatio: self.aspectRatio, initialZoomLevel: initialZoomLevel, disableFocusIndicator: self.disableFocusIndicator) {error in
-                    if let error = error {
-                        print(error)
-                        call.reject(error.localizedDescription)
-                        return
-                    }
-
+            self.cameraController.prepare(cameraPosition: self.cameraPosition, deviceId: deviceId, disableAudio: self.disableAudio, cameraMode: cameraMode, aspectRatio: self.aspectRatio, initialZoomLevel: initialZoomLevel, disableFocusIndicator: self.disableFocusIndicator) { error in
+                if let error = error {
+                    print(error)
                     DispatchQueue.main.async {
-                        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-                        NotificationCenter.default.addObserver(self,
-                                                               selector: #selector(self.handleOrientationChange),
-                                                               name: UIDevice.orientationDidChangeNotification,
-                                                               object: nil)
-                        self.completeStartCamera(call: call)
+                        self.isInitializing = false
+                        call.reject(error.localizedDescription)
                     }
+                    return
+                }
+
+                DispatchQueue.main.async {
+                    UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+                    NotificationCenter.default.addObserver(self,
+                                                           selector: #selector(self.handleOrientationChange),
+                                                           name: UIDevice.orientationDidChangeNotification,
+                                                           object: nil)
+                    self.completeStartCamera(call: call)
                 }
             }
-        })
+        }
+
+        let handleDenied: (AVAuthorizationStatus) -> Void = { _ in
+            DispatchQueue.main.async {
+                self.isInitializing = false
+                call.reject("camera permission denied. enable camera access in Settings.", "cameraPermissionDenied")
+            }
+        }
+
+        let authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
+
+        switch authorizationStatus {
+        case .authorized:
+            beginStart()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                if granted {
+                    beginStart()
+                } else {
+                    let currentStatus = AVCaptureDevice.authorizationStatus(for: .video)
+                    handleDenied(currentStatus)
+                }
+            }
+        case .denied, .restricted:
+            handleDenied(authorizationStatus)
+        @unknown default:
+            handleDenied(authorizationStatus)
+        }
     }
 
     private func completeStartCamera(call: CAPPluginCall) {
@@ -766,6 +862,94 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             }
 
             call.resolve()
+        }
+    }
+
+    public override func checkPermissions(_ call: CAPPluginCall) {
+        let disableAudio = call.getBool("disableAudio") ?? true
+        let cameraStatus = self.mapAuthorizationStatus(AVCaptureDevice.authorizationStatus(for: .video))
+
+        var result: [String: Any] = [
+            "camera": cameraStatus,
+        ]
+
+        if disableAudio == false {
+            let audioPermission = AVAudioSession.sharedInstance().recordPermission
+            result["microphone"] = self.mapAudioPermission(audioPermission)
+        }
+
+        call.resolve(result)
+    }
+
+    public override func requestPermissions(_ call: CAPPluginCall) {
+        let disableAudio = call.getBool("disableAudio") ?? true
+        self.disableAudio = disableAudio
+
+        let title = call.getString("title") ?? "Camera Permission Needed"
+        let message = call.getString("message") ?? "Enable camera access in Settings to use the preview."
+        let openSettingsText = call.getString("openSettingsButtonTitle") ?? "Open Settings"
+        let cancelText = call.getString("cancelButtonTitle") ?? "Cancel"
+        let showSettingsAlert = call.getBool("showSettingsAlert") ?? false
+
+        var currentCameraStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        let audioSession = AVAudioSession.sharedInstance()
+        var currentAudioStatus: AVAudioSession.RecordPermission? = disableAudio ? nil : audioSession.recordPermission
+
+        let dispatchGroup = DispatchGroup()
+        var pendingRequests = 0
+
+        if currentCameraStatus == .notDetermined {
+            pendingRequests += 1
+            dispatchGroup.enter()
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                currentCameraStatus = granted ? .authorized : .denied
+                dispatchGroup.leave()
+            }
+        }
+
+        if let audioStatus = currentAudioStatus,
+           audioStatus == .undetermined {
+            pendingRequests += 1
+            dispatchGroup.enter()
+            audioSession.requestRecordPermission { granted in
+                currentAudioStatus = granted ? .granted : .denied
+                dispatchGroup.leave()
+            }
+        }
+
+        let finalizeResponse: () -> Void = { [weak self] in
+            guard let self = self else { return }
+
+            let cameraResult = self.mapAuthorizationStatus(currentCameraStatus)
+            var result: [String: Any] = [
+                "camera": cameraResult,
+            ]
+
+            if let audioStatus = currentAudioStatus {
+                result["microphone"] = self.mapAudioPermission(audioStatus)
+            }
+
+            let shouldShowAlert = showSettingsAlert &&
+                (cameraResult == "denied" ||
+                 ((result["microphone"] as? String) == "denied"))
+
+            guard shouldShowAlert else {
+                call.resolve(result)
+                return
+            }
+
+            self.presentCameraPermissionAlert(title: title,
+                                              message: message,
+                                              openSettingsText: openSettingsText,
+                                              cancelText: cancelText) {
+                call.resolve(result)
+            }
+        }
+
+        if pendingRequests == 0 {
+            DispatchQueue.main.async(execute: finalizeResponse)
+        } else {
+            dispatchGroup.notify(queue: .main, execute: finalizeResponse)
         }
     }
     // Get user's cache directory path

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -170,10 +170,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     }
 
     private func presentCameraPermissionAlert(title: String,
-                                               message: String,
-                                               openSettingsText: String,
-                                               cancelText: String,
-                                               completion: (() -> Void)? = nil) {
+                                              message: String,
+                                              openSettingsText: String,
+                                              cancelText: String,
+                                              completion: (() -> Void)? = nil) {
         DispatchQueue.main.async {
             guard let viewController = self.bridge?.viewController else {
                 completion?()
@@ -865,12 +865,12 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         }
     }
 
-    public override func checkPermissions(_ call: CAPPluginCall) {
+    override public func checkPermissions(_ call: CAPPluginCall) {
         let disableAudio = call.getBool("disableAudio") ?? true
         let cameraStatus = self.mapAuthorizationStatus(AVCaptureDevice.authorizationStatus(for: .video))
 
         var result: [String: Any] = [
-            "camera": cameraStatus,
+            "camera": cameraStatus
         ]
 
         if disableAudio == false {
@@ -881,7 +881,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
         call.resolve(result)
     }
 
-    public override func requestPermissions(_ call: CAPPluginCall) {
+    override public func requestPermissions(_ call: CAPPluginCall) {
         let disableAudio = call.getBool("disableAudio") ?? true
         self.disableAudio = disableAudio
 
@@ -922,7 +922,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
             let cameraResult = self.mapAuthorizationStatus(currentCameraStatus)
             var result: [String: Any] = [
-                "camera": cameraResult,
+                "camera": cameraResult
             ]
 
             if let audioStatus = currentAudioStatus {
@@ -931,7 +931,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
 
             let shouldShowAlert = showSettingsAlert &&
                 (cameraResult == "denied" ||
-                 ((result["microphone"] as? String) == "denied"))
+                    ((result["microphone"] as? String) == "denied"))
 
             guard shouldShowAlert else {
                 call.resolve(result)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -491,7 +491,9 @@ export interface CameraPreviewPlugin {
    * @returns {Promise<CameraPermissionStatus>} A promise resolving to the current authorization states.
    * @since 8.7.0
    */
-  checkPermissions(options?: Pick<PermissionRequestOptions, 'disableAudio'>): Promise<CameraPermissionStatus>;
+  checkPermissions(
+    options?: Pick<PermissionRequestOptions, "disableAudio">,
+  ): Promise<CameraPermissionStatus>;
 
   /**
    * Requests camera (and optional microphone) permissions. If permissions are already granted or denied,

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { PluginListenerHandle } from "@capacitor/core";
+import type { PermissionState, PluginListenerHandle } from "@capacitor/core";
 
 export type CameraPosition = "rear" | "front";
 
@@ -7,6 +7,20 @@ export type FlashMode = CameraPreviewFlashMode;
 export type GridMode = "none" | "3x3" | "4x4";
 
 export type CameraPositioning = "center" | "top" | "bottom";
+
+export interface CameraPermissionStatus {
+  camera: PermissionState;
+  microphone?: PermissionState;
+}
+
+export interface PermissionRequestOptions {
+  disableAudio?: boolean;
+  showSettingsAlert?: boolean;
+  title?: string;
+  message?: string;
+  openSettingsButtonTitle?: string;
+  cancelButtonTitle?: string;
+}
 
 export enum DeviceType {
   ULTRA_WIDE = "ultraWide",
@@ -469,6 +483,28 @@ export interface CameraPreviewPlugin {
    * @since 8.0.0
    */
   getGridMode(): Promise<{ gridMode: GridMode }>;
+
+  /**
+   * Checks the current camera (and optionally microphone) permission status without prompting the system dialog.
+   *
+   * @param options Set `disableAudio` to `false` to also include microphone status (defaults to `true`).
+   * @returns {Promise<CameraPermissionStatus>} A promise resolving to the current authorization states.
+   * @since 8.7.0
+   */
+  checkPermissions(options?: Pick<PermissionRequestOptions, 'disableAudio'>): Promise<CameraPermissionStatus>;
+
+  /**
+   * Requests camera (and optional microphone) permissions. If permissions are already granted or denied,
+   * the current status is returned without prompting. When `showSettingsAlert` is true and permissions are denied,
+   * a platform specific alert guiding the user to the app settings will be presented.
+   *
+   * @param {PermissionRequestOptions} options - Configuration for the permission request behaviour.
+   * @returns {Promise<CameraPermissionStatus>} A promise resolving to the final authorization states.
+   * @since 8.7.0
+   */
+  requestPermissions(
+    options?: PermissionRequestOptions,
+  ): Promise<CameraPermissionStatus>;
 
   /**
    * Gets the horizontal field of view (FoV) for the active camera.

--- a/src/web.ts
+++ b/src/web.ts
@@ -85,10 +85,17 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
       const constraints: MediaStreamConstraints = disableAudio
         ? { video: true }
         : { video: true, audio: true };
+      let stream: MediaStream | undefined;
       try {
-        await navigator.mediaDevices.getUserMedia(constraints);
+        stream = await navigator.mediaDevices.getUserMedia(constraints);
       } catch (error) {
         console.warn("Unable to obtain camera or microphone stream", error);
+      } finally {
+        try {
+          stream?.getTracks().forEach(t => t.stop());
+        } catch (_e) {
+          /* no-op */
+        }
       }
     }
 
@@ -102,7 +109,6 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
 
     return status;
   }
-
   private mapWebPermission(
     state: WebPermissionState | undefined,
   ): PermissionState {

--- a/src/web.ts
+++ b/src/web.ts
@@ -92,7 +92,7 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
         console.warn("Unable to obtain camera or microphone stream", error);
       } finally {
         try {
-          stream?.getTracks().forEach(t => t.stop());
+          stream?.getTracks().forEach((t) => t.stop());
         } catch (_e) {
           /* no-op */
         }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,4 +1,5 @@
 import { WebPlugin } from "@capacitor/core";
+import type { PermissionState } from "@capacitor/core";
 
 import type {
   CameraDevice,
@@ -17,7 +18,6 @@ import type {
   PermissionRequestOptions,
   SafeAreaInsets,
 } from "./definitions";
-import type { PermissionState } from "@capacitor/core";
 import { DeviceType } from "./definitions";
 
 type WebPermissionState = "granted" | "denied" | "prompt";
@@ -37,7 +37,9 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   constructor() {
     super();
   }
-  async checkPermissions(options?: { disableAudio?: boolean }): Promise<CameraPermissionStatus> {
+  async checkPermissions(options?: {
+    disableAudio?: boolean;
+  }): Promise<CameraPermissionStatus> {
     const result: CameraPermissionStatus = {
       camera: "prompt",
     };
@@ -101,7 +103,9 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
     return status;
   }
 
-  private mapWebPermission(state: WebPermissionState | undefined): PermissionState {
+  private mapWebPermission(
+    state: WebPermissionState | undefined,
+  ): PermissionState {
     switch (state) {
       case "granted":
         return "granted";


### PR DESCRIPTION
## Summary

- Aligned the plugin’s permission model with Capacitor’s native PermissionState API and exposed a unified requestPermissions/checkPermissions flow across iOS, Android, and the web shim.
- Added resilient permission handling in the sample app: permissions are validated before the modal opens, denial paths surface consistent status codes, and modal dismissals are guarded to avoid “overlay does not exist” errors.
- Updated TypeScript definitions and documentation to reflect the new request options, status literals, and example usage.

## Testing

- iOS simulator/device: deny camera/mic, call CameraPreview.requestPermissions({ disableAudio: false, showSettingsAlert: true }); ensure returned status and alert behaviour; retest after granting permissions.
- Android device: run the same scenarios, verifying handling of 'prompt-with-rationale' and the Settings dialog; confirm video/audio flows still work.
- Web: invoke requestPermissions({ disableAudio: false }); confirm no settings alert, getUserMedia prompts once, and status values update as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime APIs to check and request camera and microphone permissions across iOS, Android, and Web.
  * Returns per-device permission status (camera, optional microphone) with states: prompt, prompt-with-rationale, granted, denied.
  * Configurable options: disable audio, custom titles/messages/button labels, optional settings redirection.
  * Guarded permission dialogs to prevent duplicate prompts; permission results included when dismissing camera modal.

* **Documentation**
  * README updated with new permission APIs, types, options, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->