### PR TITLE
fix(android): fix camera stop races

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -111,7 +111,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     void onSampleTakenError(String message);
     void onCameraStarted(int width, int height, int x, int y);
     void onCameraStartError(String message);
-    void onCameraStopped();
+    void onCameraStopped(CameraXView source);
   }
 
   public interface VideoRecordingCallback {
@@ -470,7 +470,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
         if (listener != null) {
           try {
-            listener.onCameraStopped();
+            listener.onCameraStopped(this);
           } catch (Exception ignored) {}
         }
       }


### PR DESCRIPTION
# Description 
- now always funnels stop() through stopSession() and clears lastSessionConfig, so a manual stop shuts the camera down even if startup wasn’t finished and prevents an automatic resume with stale settings.
- onCameraStopped events come from the live CameraXView before clearing references or replaying queued starts, avoiding stale callbacks from wiping a fresh session.
- extends the listener to include the source view and forwards it on stop, enabling the stale-callback guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved issues where the camera preview could resume with outdated settings after stopping.
  - Fixed rare cases of incorrect behavior when rapidly starting/stopping the camera.
  - Improved handling to ignore callbacks from outdated camera instances, reducing crashes and freezes.
  - Ensured camera sessions stop reliably and clear state to prevent unintended restarts.

- Stability
  - Enhanced robustness of camera preview lifecycle, minimizing race conditions and improving reliability during frequent camera interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->