### PR TITLE
fix: single x/y parameter assignment ignored

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -663,9 +663,13 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                         Log.d(TAG, "Width-limited sizing: " + width + "x" + height);
                     }
 
-                    // Center the preview
-                    x = (screenWidthPx - width) / 2;
-                    y = (screenHeightPx - height) / 2;
+                    // Center the preview only overwrite what was not explicitly set
+                    if (sessionConfig.getX() == -1){
+                        x = (screenWidthPx - width) / 2;
+                    }
+                    if (sessionConfig.getY() == -1){
+                        y = (screenHeightPx - height) / 2;
+                    }
 
                     Log.d(TAG, "Auto-centered position: x=" + x + ", y=" + y);
                 } catch (NumberFormatException e) {


### PR DESCRIPTION
If only x or y is set while the other is null, the set value was ignored and it was auto centered upon start.

Fixed to match iOS ~line 1959 Plugin.swift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Camera preview now respects user-specified positioning coordinates while maintaining auto-centering behavior for unspecified axes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->