### PR TITLE
Fix(ios) Only add orientation observer when rotateWhenOrientationChanged is true

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -83,6 +83,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     private var isInitializing: Bool = false
     private var isInitialized: Bool = false
     private var backgroundSession: AVCaptureSession?
+    private var isGeneratingOrientationNotifications: Bool = false
 
     var previewView: UIView!
     var cameraPosition = String()
@@ -679,7 +680,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                     self.cameraController.stopRequestedAfterCapture = false
                     self.cameraController.cleanup()
                     NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
-                    UIDevice.current.endGeneratingDeviceOrientationNotifications()
+                    if self.isGeneratingDeviceOrientationNotifications {
+                        UIDevice.current.endGeneratingDeviceOrientationNotifications()
+                        self.isGeneratingDeviceOrientationNotifications = false
+                    }
                     self.isInitialized = false
                     self.isInitializing = false
                 }
@@ -781,6 +785,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                 DispatchQueue.main.async {
                     if self.rotateWhenOrientationChanged == true {
                         UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+                        self.isGeneratingDeviceOrientationNotifications = true
                         NotificationCenter.default.addObserver(self,
                                                             selector: #selector(self.handleOrientationChange),
                                                             name: UIDevice.orientationDidChangeNotification,
@@ -972,7 +977,10 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
             // Remove notification observers regardless
             NotificationCenter.default.removeObserver(self)
             NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
-            UIDevice.current.endGeneratingDeviceOrientationNotifications()
+            if self.isGeneratingDeviceOrientationNotifications {
+                UIDevice.current.endGeneratingDeviceOrientationNotifications()
+                self.isGeneratingDeviceOrientationNotifications = false
+            }
 
             if self.cameraController.isCapturingPhoto && !force {
                 // Defer heavy cleanup until capture callback completes (only if not forcing)

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -83,7 +83,7 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     private var isInitializing: Bool = false
     private var isInitialized: Bool = false
     private var backgroundSession: AVCaptureSession?
-    private var isGeneratingOrientationNotifications: Bool = false
+    private var isGeneratingDeviceOrientationNotifications: Bool = false
 
     var previewView: UIView!
     var cameraPosition = String()

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -779,11 +779,13 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
                 }
 
                 DispatchQueue.main.async {
-                    UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-                    NotificationCenter.default.addObserver(self,
-                                                           selector: #selector(self.handleOrientationChange),
-                                                           name: UIDevice.orientationDidChangeNotification,
-                                                           object: nil)
+                    if self.rotateWhenOrientationChanged == true {
+                        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+                        NotificationCenter.default.addObserver(self,
+                                                            selector: #selector(self.handleOrientationChange),
+                                                            name: UIDevice.orientationDidChangeNotification,
+                                                            object: nil)
+                    }
                     self.completeStartCamera(call: call)
                 }
             }


### PR DESCRIPTION
## Description
Fixes an issue where the camera preview repositions on first start even when `rotateWhenOrientationChanged` is set to `false`.

## Problem
The orientation change observer was being added unconditionally in the `start()` method. When added, the iOS notification system fires immediately if the device already has an orientation. On first camera start, `lastOrientation` is `nil`, so the early-return check in `handleOrientationChange()` fails, causing the camera to reposition via `rawSetAspectRatio()`.

On subsequent starts, `lastOrientation` is set from the previous session, so the early-return prevents repositioning - making this a first-start-only bug.

## Solution
Wrap the orientation observer registration in a conditional check:
```swift
if self.rotateWhenOrientationChanged == true {
    // Add observer
}
```

This matches the existing pattern at line ~852 where rotation observers are already conditionally added.

## Testing
Tested on iPhone 14 Pro with:
- `rotateWhenOrientationChanged: false`
- `y: 80` (explicit positioning)

**Before:** Camera repositions to y=0 on first start  
**After:** Camera stays at y=80 on first and subsequent starts

## Changes
- Modified `start()` method to conditionally add orientation observer
- Modified `stop()` method to conditionally remove orientation observer

## Related
This only affects iOS. Android uses `OrientationEventListener` which is event-driven and doesn't fire on initial registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Camera preview now only activates device orientation notifications when "rotate on orientation change" is enabled, reducing unnecessary background activity.
  * Orientation-change handling is properly gated by the setting, ensuring stable behavior when rotation is disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->