### PR TITLE
Fix: Respect exposure lock when tapping to focus

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1975,8 +1975,10 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             currentFocusFuture.cancel(true);
         }
 
-        // Reset exposure compensation to 0 on tap-to-focus
+       //If locked don't auto adjust exposure
         if (!"LOCK".equals(currentExposureMode)) { 
+
+            // Reset exposure compensation to 0 on tap-to-focus
             try {
                 ExposureState state = camera.getCameraInfo().getExposureState();
                 Range<Integer> range = state.getExposureCompensationRange();

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1976,17 +1976,19 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
 
         // Reset exposure compensation to 0 on tap-to-focus
-        try {
-            ExposureState state = camera.getCameraInfo().getExposureState();
-            Range<Integer> range = state.getExposureCompensationRange();
-            int zeroIdx = 0;
-            if (!range.contains(0)) {
-                // Choose the closest index to 0 if 0 is not available
-                zeroIdx = Math.abs(range.getLower()) < Math.abs(range.getUpper()) ? range.getLower() : range.getUpper();
+        if (!"LOCK".equals(currentExposureMode)) { 
+            try {
+                ExposureState state = camera.getCameraInfo().getExposureState();
+                Range<Integer> range = state.getExposureCompensationRange();
+                int zeroIdx = 0;
+                if (!range.contains(0)) {
+                    // Choose the closest index to 0 if 0 is not available
+                    zeroIdx = Math.abs(range.getLower()) < Math.abs(range.getUpper()) ? range.getLower() : range.getUpper();
+                }
+                camera.getCameraControl().setExposureCompensationIndex(zeroIdx);
+            } catch (Exception e) {
+                Log.w(TAG, "setFocus: Failed to reset exposure compensation to 0", e);
             }
-            camera.getCameraControl().setExposureCompensationIndex(zeroIdx);
-        } catch (Exception e) {
-            Log.w(TAG, "setFocus: Failed to reset exposure compensation to 0", e);
         }
 
         int viewWidth = previewView.getWidth();

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -1698,11 +1698,15 @@ extension CameraController {
             // Set the focus point
             device.focusPointOfInterest = point
 
+            // Skip exposure point if exposure locked
+            if device.exposureMode != .locked {
+
             // Also set exposure point if supported
-            if device.isExposurePointOfInterestSupported && device.isExposureModeSupported(.autoExpose) {
-                device.exposureMode = .autoExpose
-                device.setExposureTargetBias(0.0) { _ in }
-                device.exposurePointOfInterest = point
+                if device.isExposurePointOfInterestSupported && device.isExposureModeSupported(.autoExpose) {
+                    device.exposureMode = .autoExpose
+                    device.setExposureTargetBias(0.0) { _ in }
+                    device.exposurePointOfInterest = point
+                }
             }
 
             device.unlockForConfiguration()
@@ -2176,12 +2180,14 @@ extension CameraController: UIGestureRecognizerDelegate {
                 device.focusPointOfInterest = CGPoint(x: CGFloat(devicePoint?.x ?? 0), y: CGFloat(devicePoint?.y ?? 0))
                 device.focusMode = focusMode
             }
-
-            let exposureMode = AVCaptureDevice.ExposureMode.autoExpose
-            if device.isExposurePointOfInterestSupported && device.isExposureModeSupported(exposureMode) {
-                device.exposurePointOfInterest = CGPoint(x: CGFloat(devicePoint?.x ?? 0), y: CGFloat(devicePoint?.y ?? 0))
-                device.exposureMode = exposureMode
-                device.setExposureTargetBias(0.0) { _ in }
+            // Skip exposure point if locked
+            if device.exposureMode != .locked {
+                let exposureMode = AVCaptureDevice.ExposureMode.autoExpose
+                if device.isExposurePointOfInterestSupported && device.isExposureModeSupported(exposureMode) {
+                    device.exposurePointOfInterest = CGPoint(x: CGFloat(devicePoint?.x ?? 0), y: CGFloat(devicePoint?.y ?? 0))
+                    device.exposureMode = exposureMode
+                    device.setExposureTargetBias(0.0) { _ in }
+                }
             }
         } catch {
             debugPrint(error)


### PR DESCRIPTION
## Problem
When exposure mode is set to `LOCK`, tapping to focus still resets the exposure settings. This defeats the purpose of locking exposure.

## Solution
Added a check before modifying exposure settings in both iOS and Android:

**iOS (CameraController.swift):**
- `setFocus()`: Skip exposure adjustments if `device.exposureMode == .locked`
- `handleTap()`: Skip exposure adjustments if `device.exposureMode == .locked`

**Android (CameraXView.java):**
- `setFocus()`: Skip exposure compensation reset if `currentExposureMode == "LOCK"`

## Testing
Tested on iOS and Android. Exposure now stays locked when tapping to focus with exposure mode set to LOCK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exposure lock behavior on Android and iOS. The camera now properly respects exposure lock settings and prevents automatic exposure compensation adjustments when exposure is locked by the user.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->