### PR TITLE
Fix image/video wrong orientation with portrait lock

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -366,6 +366,14 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         this.sessionConfig = config;
         cameraExecutor = Executors.newSingleThreadExecutor();
 
+        // Reset cached orientation so we don't reuse stale values across sessions
+        synchronized (accelerometerLock) {
+            lastAccelerometerValues[0] = 0f;
+            lastAccelerometerValues[1] = 0f;
+            lastAccelerometerValues[2] = 0f;
+        }
+        lastCaptureRotation = -1;
+        
         // Start accelerometer for orientation detection regardless of lock
         if (sensorManager == null) {
             sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1026,7 +1026,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         }
         
         // If no accelerometer data yet, fall back to display rotation
-        if (x == 0 && y == 0) {
+        final float epsilon = 1.0f;
+        if (Math.abs(x) < epsilon && Math.abs(y) < epsilon) {
             if (previewView != null && previewView.getDisplay() != null) {
                 return previewView.getDisplay().getRotation();
             }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -166,6 +166,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     private Sensor accelerometer;
     private final float[] lastAccelerometerValues = new float[3]; // x,y, and z
     private final Object accelerometerLock = new Object();
+    private volatile int lastCaptureRotation = -1; // -1 unknown
 
     private final SensorEventListener accelerometerListener = new SensorEventListener() {
         @Override
@@ -1079,6 +1080,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
 
         // Set rotation from accelerometer for device orientation regardless of lock
         int rotation = getRotationFromAccelerometer();
+        lastCaptureRotation = rotation;
         imageCapture.setTargetRotation(rotation);
         Log.d(TAG, "capturePhoto: Set target rotation to " + rotation + " from accelerometer");
 
@@ -1835,7 +1837,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         int previewH = Math.max(1, bounds.height());
 
         // Check if device physical orientation differs from UI orientation
-        int rotation = getRotationFromAccelerometer();
+        int rotation = (lastCaptureRotation != -1) ? lastCaptureRotation : getRotationFromAccelerometer();
         boolean physicalInLandscape = (rotation == android.view.Surface.ROTATION_90 || rotation == android.view.Surface.ROTATION_270);
         boolean previewIsPortrait = previewH > previewW;
         

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -364,6 +364,15 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
     public void startSession(CameraSessionConfiguration config) {
         this.sessionConfig = config;
         cameraExecutor = Executors.newSingleThreadExecutor();
+
+        // Start accelerometer for orientation detection regardless of lock
+        if (sensorManager == null) {
+            sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+            accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+        }
+        if (accelerometer != null) {
+            sensorManager.registerListener(accelerometerListener, accelerometer, SensorManager.SENSOR_DELAY_UI);
+        }
         synchronized (operationLock) {
             activeOperations = 0;
             stopPending = false;

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -41,7 +41,7 @@ class CameraController: NSObject {
     // For capture only - uses accelerometer to detect physical orientation to properly position videos/images
     private func getPhysicalOrientation() -> AVCaptureVideoOrientation {
         guard let accelerometerData = motionManager.accelerometerData else {
-            return getVideoOrientation() // Fallback to interface in case of accelerometer fail
+            return lastCaptureOrientation ?? getVideoOrientation() // Fallback to interface in case of accelerometer fail
         }
 
         let x = accelerometerData.acceleration.x
@@ -360,9 +360,12 @@ extension CameraController {
             }
 
             // Start accelerometer
-            if !self.motionManager.isAccelerometerActive {
-                self.motionManager.startAccelerometerUpdates()
-            }
+            if self.motionManager.isAccelerometerAvailable {
++                self.motionManager.accelerometerUpdateInterval = 1.0 / 60.0
++                if !self.motionManager.isAccelerometerActive {
++                    self.motionManager.startAccelerometerUpdates()
++                }
++            }
 
             do {
                 // Create session if needed

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -457,7 +457,9 @@ extension CameraController {
                     completionHandler(nil)
                 }
             } catch {
-                if startedAccelerometer (self.motionManager.stopAccelerometerUpdates())
+                if startedAccelerometer {
+                    self.motionManager.stopAccelerometerUpdates()
+                    }
                 DispatchQueue.main.async {
                     completionHandler(error)
                 }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -360,10 +360,12 @@ extension CameraController {
             }
 
             // Start accelerometer
+            var startedAccelerometer = false
             if self.motionManager.isAccelerometerAvailable {
 +                self.motionManager.accelerometerUpdateInterval = 1.0 / 60.0
 +                if !self.motionManager.isAccelerometerActive {
 +                    self.motionManager.startAccelerometerUpdates()
+                     startedAccelerometer = true
 +                }
 +            }
 
@@ -455,6 +457,7 @@ extension CameraController {
                     completionHandler(nil)
                 }
             } catch {
+                if startedAccelerometer (self.motionManager.stopAccelerometerUpdates())
                 DispatchQueue.main.async {
                     completionHandler(error)
                 }

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -362,12 +362,12 @@ extension CameraController {
             // Start accelerometer
             var startedAccelerometer = false
             if self.motionManager.isAccelerometerAvailable {
-+                self.motionManager.accelerometerUpdateInterval = 1.0 / 60.0
-+                if !self.motionManager.isAccelerometerActive {
-+                    self.motionManager.startAccelerometerUpdates()
+                self.motionManager.accelerometerUpdateInterval = 1.0 / 60.0
+                if !self.motionManager.isAccelerometerActive {
+                    self.motionManager.startAccelerometerUpdates()
                      startedAccelerometer = true
-+                }
-+            }
+                }
+            }
 
             do {
                 // Create session if needed

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -94,6 +94,7 @@ class CameraController: NSObject {
     private var lastZoomUpdateTime: TimeInterval = 0
     private let zoomUpdateThrottle: TimeInterval = 1.0 / 60.0 // 60 FPS max
     private let motionManager = CMMotionManager()
+    private var lastCaptureOrientation: AVCaptureVideoOrientation?
 
     var videoFileURL: URL?
     private let saneMaxZoomFactor: CGFloat = 25.5
@@ -927,7 +928,9 @@ extension CameraController {
 
         // Make sure capture is getting the physical orientation not interface orientation
         if let connection = photoOutput.connection(with: .video) {
-            connection.videoOrientation = self.getPhysicalOrientation()
+            let captureOrientation = self.getPhysicalOrientation()
+            self.lastCaptureOrientation = captureOrientation
+            connection.videoOrientation = captureOrientation
         }
         let settings = AVCapturePhotoSettings()
         // Configure photo capture settings optimized for speed
@@ -1321,7 +1324,7 @@ extension CameraController {
         }
 
         // Use physical orientation for capture works with portrait lock
-        let orientation = self.getPhysicalOrientation()
+        let orientation = self.lastCaptureOrientation ?? self.getPhysicalOrientation()
         let isPortrait = (orientation == .portrait || orientation == .portraitUpsideDown)
 
         let ratioWidth: CGFloat

--- a/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/CameraController.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import UIKit
 import CoreLocation
 import UniformTypeIdentifiers
+import CoreMotion
 
 class CameraController: NSObject {
     private func getVideoOrientation() -> AVCaptureVideoOrientation {
@@ -36,6 +37,24 @@ class CameraController: NSObject {
         }
         return orientation
     }
+
+    // For capture only - uses accelerometer to detect physical orientation to properly position videos/images
+    private func getPhysicalOrientation() -> AVCaptureVideoOrientation {
+        guard let accelerometerData = motionManager.accelerometerData else {
+            return getVideoOrientation() // Fallback to interface in case of accelerometer fail
+        }
+
+        let x = accelerometerData.acceleration.x
+        let y = accelerometerData.acceleration.y
+
+        if abs(x) > abs(y) {
+            // Landscape
+            return x > 0 ? .landscapeLeft : .landscapeRight
+        } else {
+            // Portrait
+            return y > 0 ? .portraitUpsideDown : .portrait
+            }
+        }
 
     var captureSession: AVCaptureSession?
     var disableFocusIndicator: Bool = false
@@ -74,6 +93,7 @@ class CameraController: NSObject {
     var zoomFactor: CGFloat = 1.0
     private var lastZoomUpdateTime: TimeInterval = 0
     private let zoomUpdateThrottle: TimeInterval = 1.0 / 60.0 // 60 FPS max
+    private let motionManager = CMMotionManager()
 
     var videoFileURL: URL?
     private let saneMaxZoomFactor: CGFloat = 25.5
@@ -336,6 +356,11 @@ extension CameraController {
                     completionHandler(CameraControllerError.unknown)
                 }
                 return
+            }
+
+            // Start accelerometer
+            if !self.motionManager.isAccelerometerActive {
+                self.motionManager.startAccelerometerUpdates()
             }
 
             do {
@@ -900,6 +925,10 @@ extension CameraController {
             return
         }
 
+        // Make sure capture is getting the physical orientation not interface orientation
+        if let connection = photoOutput.connection(with: .video) {
+            connection.videoOrientation = self.getPhysicalOrientation()
+        }
         let settings = AVCapturePhotoSettings()
         // Configure photo capture settings optimized for speed
         // Only use high res if explicitly requesting large dimensions
@@ -1285,9 +1314,26 @@ extension CameraController {
     }
 
     func cropImageToAspectRatio(image: UIImage, aspectRatio: String) -> UIImage? {
-        guard let ratio = parseAspectRatio(aspectRatio) else {
+        let components = aspectRatio.split(separator: ":").compactMap {Float(String($0))}
+        guard components.count == 2 else {            
             print("[CameraPreview] cropImageToAspectRatio - Failed to parse aspect ratio: \(aspectRatio)")
             return image
+        }
+
+        // Use physical orientation for capture works with portrait lock
+        let orientation = self.getPhysicalOrientation()
+        let isPortrait = (orientation == .portrait || orientation == .portraitUpsideDown)
+
+        let ratioWidth: CGFloat
+        let ratioHeight: CGFloat
+        if isPortrait {
+            // For portrait 4:3 becomes 3:4, 16:9 becomes 9:16
+            ratioWidth = CGFloat(components[1])
+            ratioHeight = CGFloat(components[0])
+        } else {
+            // For landscape keep original
+            ratioWidth = CGFloat(components[0])
+            ratioHeight = CGFloat(components[1])
         }
 
         // Only normalize the image orientation if it's not already correct
@@ -1302,10 +1348,10 @@ extension CameraController {
 
         let imageSize = normalizedImage.size
         let imageAspectRatio = imageSize.width / imageSize.height
-        let targetAspectRatio = ratio.width / ratio.height
+        let targetAspectRatio = ratioWidth / ratioHeight
 
         print("[CameraPreview] cropImageToAspectRatio - Original image: \(imageSize.width)x\(imageSize.height) (ratio: \(imageAspectRatio))")
-        print("[CameraPreview] cropImageToAspectRatio - Target ratio: \(ratio.width):\(ratio.height) (ratio: \(targetAspectRatio))")
+        print("[CameraPreview] cropImageToAspectRatio - Target ratio: \(ratioWidth):\(ratioHeight) (ratio: \(targetAspectRatio))")
 
         var cropRect: CGRect
 
@@ -1878,6 +1924,7 @@ extension CameraController {
             captureSession.outputs.forEach { captureSession.removeOutput($0) }
         }
 
+        self.motionManager.stopAccelerometerUpdates()
         self.previewLayer?.removeFromSuperlayer()
         self.previewLayer = nil
 
@@ -2103,18 +2150,8 @@ extension CameraController {
         //
         if let connection = fileVideoOutput.connection(with: .video) {
             if connection.isEnabled == false { connection.isEnabled = true }
-            switch UIDevice.current.orientation {
-            case .landscapeRight:
-                connection.videoOrientation = .landscapeLeft
-            case .landscapeLeft:
-                connection.videoOrientation = .landscapeRight
-            case .portrait:
-                connection.videoOrientation = .portrait
-            case .portraitUpsideDown:
-                connection.videoOrientation = .portraitUpsideDown
-            default:
-                connection.videoOrientation = .portrait
-            }
+            // Goes off accelerometer now
+            connection.videoOrientation = self.getPhysicalOrientation()
         }
 
         let identifier = UUID()


### PR DESCRIPTION
- Use accelerometer to detect physical device orientation
- iOS: CoreMotion for capture orientation, display orientation for preview
-- Helper function getPhysicalOrientation() in iOS to find physical orientation. Used during capture instances for video/image and cropping image. Preview orientation remains untouched.
- Android: SensorManager for capture orientation
-- Helper function getRotationFromAccelerometer() to find physical orientation. Used during capture instances for video/image and cropping image. Preview orientation remains untouched.
- Fixes photos/videos being sideways when device is rotated but UI is locked"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accelerometer-driven physical orientation detection for preview, photo capture, and video recording on both platforms.
  * Captures and recordings now apply device rotation so outputs respect real-world orientation.
  * Cropping, aspect-ratio handling, and preview alignment now adapt to device orientation, including after camera flips.

* **Bug Fixes**
  * Fixed mismatches between UI/interface orientation and physical device orientation that caused incorrect crops or rotated outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->