### PR TITLE
Fix flicker on resume android

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -79,6 +79,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     protected void handleOnResume() {
         super.handleOnResume();
         if (lastSessionConfig != null) {
+            // Set to black to avoid flicker, transparent set later
+            if (lastSessionConfig.isToBack()) {
+                try {
+                    getBridge().getActivity().getWindow()
+                        .setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK));
+                    getBridge().getWebView().setBackgroundColor(android.graphics.Color.BLACK);
+                } catch (Exception ignored) {}
+            }
             // Recreate camera with last known configuration
             if (cameraXView == null) {
                 cameraXView = new CameraXView(getContext(), getBridge().getWebView());

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -947,6 +947,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                         // Set to solid black first to prevent flickering during transition
                         // This provides a stable base before camera preview is ready
                         getBridge().getActivity().getWindow().setBackgroundDrawable(new ColorDrawable(Color.BLACK));
+                        getBridge().getWebView().setBackgroundColor(Color.argb(1, 0, 0, 0));
                     } catch (Exception ignored) {}
                 }
                 DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
@@ -1651,7 +1652,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                     .getActivity()
                     .runOnUiThread(() -> {
                         try {
-                            getBridge().getActivity().getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+                            // Use "almost transparent" to avoid WebView hardware acceleration compositing bug
+                            getBridge().getActivity().getWindow().setBackgroundDrawable(new ColorDrawable(Color.argb(1,0,0,0)));
                         } catch (Exception e) {
                             Log.w(TAG, "Failed to set window background to transparent", e);
                         }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -1026,7 +1026,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
                         // This prevents flickering during camera initialization
                         if (sessionConfig.isToBack()) {
                             webView.post(() -> {
-                                webView.setBackgroundColor(android.graphics.Color.TRANSPARENT);
+                                // Use "almost transparent" to avoid WebView hardware acceleration compositing bug
+                                webView.setBackgroundColor(android.graphics.Color.argb(1,0,0,0));
                             });
                         }
 


### PR DESCRIPTION
On camera start the flicker was fixed, but when putting app into background and foreground it starts to flicker the background where the camera preview is not. 

Also of note is that when you have UI besides the camera preview (whether on top of the preview or above/below it on the screen) that toggles on/off it does not get repainted on start. For example I have a slider bar for exposure control. When I start the camera and toggle it on/off it will always stay visible. I can interact with it when it's supposed to be visible and can't when it's not supposed to be there.

When the app goes into the background and foreground then it toggles as it should. Suggesting a repainting issue that happens only on camera start. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced camera preview flicker when resuming or sending the camera view to the background, improving visual smoothness during app transitions.
  * Improved background handling to avoid visual glitches related to the web view while the camera starts or transitions, especially on hardware-accelerated devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->