### PR TITLE
Fix on resume flicker (Android)

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -79,6 +79,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     protected void handleOnResume() {
         super.handleOnResume();
         if (lastSessionConfig != null) {
+            // Set to black to avoid flicker, transparent set later
+            if (lastSessionConfig.isToBack()) {
+                try {
+                    getBridge().getActivity().getWindow()
+                        .setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK));
+                    getBridge().getWebView().setBackgroundColor(android.graphics.Color.BLACK);
+                } catch (Exception ignored) {}
+            }
             // Recreate camera with last known configuration
             if (cameraXView == null) {
                 cameraXView = new CameraXView(getContext(), getBridge().getWebView());

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -82,7 +82,9 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             // Set to black to avoid flicker, transparent set later
             if (lastSessionConfig.isToBack()) {
                 try {
-                    getBridge().getActivity().getWindow()
+                    getBridge()
+                        .getActivity()
+                        .getWindow()
                         .setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.BLACK));
                     getBridge().getWebView().setBackgroundColor(android.graphics.Color.BLACK);
                 } catch (Exception ignored) {}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@ionic/eslint-config": "^0.4.0",
         "@ionic/prettier-config": "^4.0.0",
         "@ionic/swiftlint-config": "^2.0.0",
+        "@rollup/rollup-darwin-x64": "^4.57.1",
         "@types/node": "^24.10.1",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.31.0",
@@ -107,7 +108,7 @@
 
     "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.57.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w=="],
 
     "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w=="],
 
@@ -800,6 +801,8 @@
     "path-scurry/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "rollup/@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,18 +60,17 @@
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
-    "@rollup/rollup-darwin-x64": "^4.57.1",
     "@types/node": "^24.10.1",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
-    "prettier-pretty-check": "^0.2.0",
     "rimraf": "^6.1.0",
     "rollup": "^4.53.2",
     "swiftlint": "^2.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "prettier-pretty-check": "^0.2.0"
   },
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -60,17 +60,18 @@
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
+    "@rollup/rollup-darwin-x64": "^4.57.1",
     "@types/node": "^24.10.1",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.31.0",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.7",
+    "prettier-pretty-check": "^0.2.0",
     "rimraf": "^6.1.0",
     "rollup": "^4.53.2",
     "swiftlint": "^2.0.0",
-    "typescript": "^5.9.3",
-    "prettier-pretty-check": "^0.2.0"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "@capacitor/core": ">=8.0.0"


### PR DESCRIPTION
## What
- Changed onHandleResume in Android to initially set to black if config is set toBack : true. This avoided flickering/racing condition as the camera resumed.

## Why
- A previous PR had fixed the on start flickering but this part was missed. Makes for a more pleasant and consistent UI for users.

## How
-Set to black like the on start method did.

## Testing
-Tested on Samsung Galaxy A16

## Not Tested
-Non samsung devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed camera preview flickering when positioned behind the WebView on Android during app resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->