### PR TITLE
Fix on resume keep isCentered (Android)

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -2759,7 +2759,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         // Determine current position based on session config and flip it
         String currentPosition = sessionConfig.getPosition();
         String newPosition = "front".equals(currentPosition) ? "rear" : "front";
-
+        // Maintain centered config
+        boolean wasCentered = sessionConfig.isCentered();
         Log.d(TAG, "flipCamera: Switching from " + currentPosition + " to " + newPosition);
 
         sessionConfig = new CameraSessionConfiguration(
@@ -2781,6 +2782,8 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
             sessionConfig.getDisableFocusIndicator(), // disableFocusIndicator
             sessionConfig.isVideoModeEnabled() // enableVideoMode
         );
+
+        sessionConfig.setCentered(wasCentered);
 
         // Clear current device ID to force position-based selection
         currentDeviceId = null;


### PR DESCRIPTION
## What
- Changed flipCamera in Android to check for isCentered and set if necessary. Without this the previewSize was incorrectly resizing when the app would cycle from background/foreground.

## Why
- After flipping the camera and then cycling the app through background/foreground it would cause the preview size to suddenly change. This leads to an inconsistent user experience.

## How
- Check for isCentered and set in the configs similar to how switchToDevice does.

## Testing
-Tested on Samsung Galaxy A16

## Not Tested
-Non samsung devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Camera preview now maintains its centered position when switching between front and back cameras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->