### PR TITLE
Fix aspectMode "cover" incorrectly skips aspect ratio container size on Android only

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -807,7 +807,6 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         int width = sessionConfig.getWidth();
         int height = sessionConfig.getHeight();
         String aspectRatio = sessionConfig.getAspectRatio();
-        String aspectMode = sessionConfig.getAspectMode();
 
         // Get comprehensive display information
         int screenWidthPx, screenHeightPx;

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -877,7 +877,7 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         );
 
         // Apply aspect ratio if specified
-        if (aspectRatio != null && !aspectRatio.isEmpty() && sessionConfig.isCentered() && !"cover".equals(aspectMode)) {
+        if (aspectRatio != null && !aspectRatio.isEmpty() && sessionConfig.isCentered()) {
             String[] ratios = aspectRatio.split(":");
             if (ratios.length == 2) {
                 try {


### PR DESCRIPTION
# What
Removed the !"cover".equals(aspectMode) guard from calculatePreviewLayoutParams() so the preview container is always sized to the requested aspect ratio regardless of aspectMode.

# Why
On iOS, the preview view is always sized to the requested aspect ratio (e.g. 4:3), and aspectMode only controls how the camera feed scales within that container — "cover" uses resizeAspectFill, "contain" uses resizeAspect. On Android, the !"cover".equals(aspectMode) condition causes the entire aspect ratio container sizing to be skipped when aspectMode is "cover", resulting in a full-screen container instead of the requested 4:3 box. This creates a platform inconsistency where the same parameters produce different results on iOS and Android.

# How
Changed calculatePreviewLayoutParams() from:
if (aspectRatio != null && !aspectRatio.isEmpty() && sessionConfig.isCentered() && !"cover".equals(aspectMode)) {

to 
if (aspectRatio != null && !aspectRatio.isEmpty() && sessionConfig.isCentered()) {

The container is now always sized to the requested aspect ratio. PreviewView.ScaleType.FILL_CENTER (cover) and FIT_CENTER (contain) then handle scaling the camera feed within that correctly-sized container, matching iOS behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Camera preview sizing and centering now correctly apply whenever an aspect ratio is set and centering is enabled, regardless of preview mode. This ensures consistent aspect-ratio-based auto-sizing and centered display across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->