### PR TITLE
fix(ios): use interface orientation instead of device orientation in isPortrait()

### DIFF
--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1947,23 +1947,21 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     }
 
     private func isPortrait() -> Bool {
-        let orientation = UIDevice.current.orientation
-        if orientation.isValidInterfaceOrientation {
-            return orientation.isPortrait
-        } else {
-            let interfaceOrientation: UIInterfaceOrientation? = {
-                if Thread.isMainThread {
-                    return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.interfaceOrientation
-                } else {
-                    var value: UIInterfaceOrientation?
-                    DispatchQueue.main.sync {
-                        value = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.interfaceOrientation
-                    }
-                    return value
+        let interfaceOrientation: UIInterfaceOrientation? = {
+            let lookup: () -> UIInterfaceOrientation? = {
+                return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.interfaceOrientation
+            }
+            if Thread.isMainThread {
+                return lookup()
+            } else {
+                var value: UIInterfaceOrientation?
+                DispatchQueue.main.sync {
+                    value = lookup()
                 }
-            }()
-            return interfaceOrientation?.isPortrait ?? false
-        }
+                return value
+            }
+        }()
+        return interfaceOrientation?.isPortrait ?? true
     }
 
     private func calculateCameraFrame(xPosition: CGFloat? = nil, yPosition: CGFloat? = nil, width: CGFloat? = nil, height: CGFloat? = nil, aspectRatio: String? = nil) -> CGRect {

--- a/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
+++ b/ios/Sources/CapgoCameraPreviewPlugin/Plugin.swift
@@ -1949,7 +1949,9 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelega
     private func isPortrait() -> Bool {
         let interfaceOrientation: UIInterfaceOrientation? = {
             let lookup: () -> UIInterfaceOrientation? = {
-                return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.interfaceOrientation
+                let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+                let activeScene = scenes.first { $0.activationState == .foregroundActive }
+                return (activeScene ?? scenes.first)?.interfaceOrientation
             }
             if Thread.isMainThread {
                 return lookup()


### PR DESCRIPTION
# What 
Updates the isPortrait() method in Plugin.swift to read the app's interface orientation from the active window scene instead of the physical device orientation from UIDevice.current.orientation.
Single-function change, around 20 lines of Swift.

# Why 
The current isPortrait() implementation reads UIDevice.current.orientation (physical device pose from the accelerometer) rather than the app's actual UI orientation. This produces incorrect preview frame sizing when the user holds the phone in an orientation that differs from the app's interface orientation — most notably for apps locked to portrait via Info.plist when the user has rotation lock disabled and holds the device in landscape.

For example, with aspectRatio: "4:3" in a 428×926 portrait webview:

App is portrait-locked, user holds phone in portrait → UIDevice.current.orientation returns .portrait → preview correctly sized as 428×571 (3:4 portrait).
App is portrait-locked, user holds phone in landscape with rotation lock off → UIDevice.current.orientation returns .landscapeLeft → isPortrait() returns false → preview incorrectly sized as 428×321 (4:3 landscape) inside the portrait webview, producing a squished preview.

The plugin's existing iOS code already uses interface orientation in the right places — CameraController.getVideoOrientation() (line 8) and prepareOutputs() (lines 346/365) both correctly read from windowScene.interfaceOrientation. Only Plugin.swift::isPortrait() was reading from device orientation, creating an inconsistency.

Note on capture path: this change does not affect captured photo or video orientation. CameraController.cropImageToAspectRatio() (line 1439) and the video recording path (line 2290) intentionally use getPhysicalOrientation() (accelerometer-based), with an explicit code comment stating this is for capture to work correctly with portrait lock. That logic is untouched and continues to work as before. Landscape-captured photos still come out as landscape images.

## Before bug fix
<img width="585" height="1266" alt="IMG_2157" src="https://github.com/user-attachments/assets/30dda9d2-a8cb-485e-a8ab-ce9e041a27a9" />

## After bug fix
<img width="585" height="1266" alt="IMG_2156" src="https://github.com/user-attachments/assets/e47544be-37bd-4b2c-aeac-ae3aa8bb6697" />

# How
Removed the UIDevice.current.orientation read and the isValidInterfaceOrientation branching. The function now always reads windowScene.interfaceOrientation directly, preserving the existing thread-safety pattern (main-thread inline, background-thread via DispatchQueue.main.sync).
Also changed the default fallback from false to true for the case where no window scene is available (rare, but possible very early in app lifecycle). Portrait is the safer default since most iOS apps are portrait-first and a too-tall preview frame degrades more gracefully than a too-short one.

I chose to continue use of the deprecatedUIWindowScene.interfaceOrientation instead of effectiveGeometry.interfaceOrientation to keep it in line with rest of the plugin.

# Testing

Tested in the example app, modified to be portrait-locked via Info.plist, on a physical iPhone with rotation lock disabled.
Reproduction of the bug on main:

Started camera with aspectRatio: "4:3" while holding the phone in landscape → preview rendered squished at 4:3 landscape dimensions inside the portrait webview. Screenshots attached.

Verification with the patch applied:

Started camera in portrait → preview renders correctly at 3:4 portrait dimensions.
Started camera in landscape (rotation lock off) → preview renders correctly at 3:4 portrait dimensions. Bug is fixed.
Started camera in portrait, then rotated phone to landscape → preview remains correctly sized (no regression in the case that already worked).
Toggled rotation lock on/off mid-session → no effect on preview sizing, as expected.
Took photos in portrait orientation → photos saved with correct portrait orientation.
Took photos while holding phone in landscape → photos saved with correct landscape orientation. Capture path is unaffected by the change.
Switched between front and back cameras in different physical orientations → preview remains correctly sized.

# Not Tested
Video capture (this appeared to use different code in CameraController.swift anyway though)
Ipad



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced camera preview orientation detection to improve reliability when handling device orientation changes between portrait and landscape modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->