### PR TITLE
fix(android): stabilize toBack compositor transparency

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -15,7 +15,6 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.net.Uri;
@@ -54,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -104,11 +102,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 cameraXView.setListener(this);
             }
             if (lastSessionConfig.isToBack()) {
-                if (usesFullStackTransparentBackgroundWorkaround()) {
-                    activateTransparentBackgroundsForToBack(cameraXView);
-                } else {
-                    prepareTransparentBackgroundsForToBack(cameraXView);
-                }
+                applyToBackVisualState(cameraXView);
             } else {
                 toBackVisualStateActive = false;
             }
@@ -128,9 +122,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         lastSessionConfig = null;
         clearActiveBarcodeScanner();
         toBackVisualStateActive = false;
-        restoreOriginalWindowBackground(getBridge().getActivity());
         restoreWebViewVisualState();
-        restoreSystemUiForToBackMode(getBridge().getActivity());
         unregisterScreenLockReceiver();
     }
 
@@ -159,16 +151,11 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     private String lastOrientationStr = "unknown";
     private boolean lastDisableAudio = true;
     private boolean lastIncludeSafeAreaInsets = false;
-    private Drawable originalWindowBackground;
-    private boolean originalWindowBackgroundCaptured = false;
     private Drawable originalWebViewBackground;
     private boolean originalWebViewBackgroundCaptured = false;
     private Float originalWebViewAlpha;
     private Drawable originalWebViewParentBackground;
     private boolean originalWebViewParentBackgroundCaptured = false;
-    private Integer originalStatusBarColor;
-    private Integer originalNavigationBarColor;
-    private Boolean originalNavigationBarContrastEnforced;
     private volatile boolean toBackVisualStateActive = false;
     private boolean isCameraPermissionDialogShowing = false;
     private boolean pendingStartBarcodeScanner = false;
@@ -798,6 +785,9 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         ) {
             cameraXView = new CameraXView(getContext(), getBridge().getWebView());
             cameraXView.setListener(this);
+            if (lastSessionConfig.isToBack()) {
+                applyToBackVisualState(cameraXView);
+            }
             requestBarcodeScannerRestartAfterCameraResume();
             cameraRestartAfterResumeInProgress = true;
             cameraXView.startSession(lastSessionConfig);
@@ -840,9 +830,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 lastSessionConfig = null;
                 clearActiveBarcodeScanner();
                 toBackVisualStateActive = false;
-                restoreOriginalWindowBackground(getBridge().getActivity());
                 restoreWebViewVisualState();
-                restoreSystemUiForToBackMode(getBridge().getActivity());
                 call.resolve();
             });
     }
@@ -1360,13 +1348,8 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         getBridge()
             .getActivity()
             .runOnUiThread(() -> {
-                lockSystemUiForToBackMode(getBridge().getActivity(), toBack);
                 if (toBack) {
-                    if (usesFullStackTransparentBackgroundWorkaround()) {
-                        activateTransparentBackgroundsForToBack(cameraXView);
-                    } else {
-                        prepareTransparentBackgroundsForToBack(cameraXView);
-                    }
+                    applyToBackVisualState(cameraXView);
                 } else {
                     toBackVisualStateActive = false;
                 }
@@ -1985,36 +1968,6 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         return false;
     }
 
-    private boolean isMiuiDevice() {
-        String manufacturer = Build.MANUFACTURER != null ? Build.MANUFACTURER.toLowerCase(Locale.US) : "";
-        String brand = Build.BRAND != null ? Build.BRAND.toLowerCase(Locale.US) : "";
-        return manufacturer.contains("xiaomi") || brand.contains("xiaomi") || brand.contains("redmi") || brand.contains("poco");
-    }
-
-    private boolean usesFullStackTransparentBackgroundWorkaround() {
-        String manufacturer = Build.MANUFACTURER != null ? Build.MANUFACTURER.toLowerCase(Locale.US) : "";
-        String brand = Build.BRAND != null ? Build.BRAND.toLowerCase(Locale.US) : "";
-        return (
-            isMiuiDevice() ||
-            manufacturer.contains("huawei") ||
-            manufacturer.contains("honor") ||
-            brand.contains("huawei") ||
-            brand.contains("honor")
-        );
-    }
-
-    private void captureOriginalWindowBackground(Activity activity) {
-        if (activity == null) {
-            return;
-        }
-        synchronized (this) {
-            if (!originalWindowBackgroundCaptured) {
-                originalWindowBackground = activity.getWindow().getDecorView().getBackground();
-                originalWindowBackgroundCaptured = true;
-            }
-        }
-    }
-
     private void captureOriginalWebViewVisualState(WebView webView, ViewGroup webViewParent) {
         if (webView == null) {
             return;
@@ -2034,95 +1987,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         }
     }
 
-    private void restoreOriginalWindowBackground(Activity activity) {
-        final Drawable backgroundToRestore;
-        final boolean captured;
-        synchronized (this) {
-            backgroundToRestore = originalWindowBackground;
-            captured = originalWindowBackgroundCaptured;
-            originalWindowBackground = null;
-            originalWindowBackgroundCaptured = false;
-        }
-
-        if (!captured || activity == null) {
-            return;
-        }
-
-        activity.runOnUiThread(() -> {
-            try {
-                activity.getWindow().setBackgroundDrawable(backgroundToRestore);
-            } catch (Exception e) {
-                Log.w(TAG, "Failed to restore window background", e);
-            }
-        });
-    }
-
-    private int toOpaqueColor(int color) {
-        return Color.argb(255, Color.red(color), Color.green(color), Color.blue(color));
-    }
-
-    private void lockSystemUiForToBackMode(Activity activity, boolean toBack) {
-        if (activity == null) {
-            return;
-        }
-        if (!toBack) {
-            restoreSystemUiForToBackMode(activity);
-            return;
-        }
-
-        try {
-            if (originalStatusBarColor == null) {
-                originalStatusBarColor = activity.getWindow().getStatusBarColor();
-            }
-            if (originalNavigationBarColor == null) {
-                originalNavigationBarColor = activity.getWindow().getNavigationBarColor();
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && originalNavigationBarContrastEnforced == null) {
-                originalNavigationBarContrastEnforced = activity.getWindow().isNavigationBarContrastEnforced();
-            }
-
-            int statusBarColor = toOpaqueColor(originalStatusBarColor != null ? originalStatusBarColor : Color.BLACK);
-            int navigationBarColor = toOpaqueColor(originalNavigationBarColor != null ? originalNavigationBarColor : Color.BLACK);
-
-            activity.getWindow().setStatusBarColor(statusBarColor);
-            activity.getWindow().setNavigationBarColor(navigationBarColor);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                activity.getWindow().setNavigationBarContrastEnforced(false);
-            }
-        } catch (Exception e) {
-            Log.w(TAG, "Failed to lock system UI colors for toBack mode", e);
-        }
-    }
-
-    private void restoreSystemUiForToBackMode(Activity activity) {
-        final Integer statusBarColor = originalStatusBarColor;
-        final Integer navigationBarColor = originalNavigationBarColor;
-        final Boolean navigationBarContrastEnforced = originalNavigationBarContrastEnforced;
-        originalStatusBarColor = null;
-        originalNavigationBarColor = null;
-        originalNavigationBarContrastEnforced = null;
-
-        if (activity == null) {
-            return;
-        }
-
-        activity.runOnUiThread(() -> {
-            try {
-                if (statusBarColor != null) {
-                    activity.getWindow().setStatusBarColor(statusBarColor);
-                }
-                if (navigationBarColor != null) {
-                    activity.getWindow().setNavigationBarColor(navigationBarColor);
-                }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && navigationBarContrastEnforced != null) {
-                    activity.getWindow().setNavigationBarContrastEnforced(navigationBarContrastEnforced);
-                }
-            } catch (Exception ignored) {}
-        });
-    }
-
-    private void prepareTransparentBackgroundsForToBack(CameraXView visualStateOwner) {
+    private void applyToBackVisualState(CameraXView visualStateOwner) {
         Activity activity = getActivity();
         WebView webView = getBridge().getWebView();
         if (activity == null || webView == null) {
@@ -2131,34 +1996,20 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
 
         toBackVisualStateActive = true;
         final ViewGroup webViewParent = (ViewGroup) webView.getParent();
-        captureOriginalWindowBackground(activity);
         captureOriginalWebViewVisualState(webView, webViewParent);
-    }
-
-    private void activateTransparentBackgroundsForToBack(CameraXView visualStateOwner) {
-        prepareTransparentBackgroundsForToBack(visualStateOwner);
-        Activity activity = getActivity();
-        WebView webView = getBridge().getWebView();
-        if (activity == null || webView == null) {
-            return;
-        }
-
-        final ViewGroup webViewParent = (ViewGroup) webView.getParent();
 
         Runnable apply = () -> {
             try {
                 if (!toBackVisualStateActive || visualStateOwner == null || cameraXView != visualStateOwner) {
                     return;
                 }
-                boolean fullStackWorkaround = usesFullStackTransparentBackgroundWorkaround();
-                if (fullStackWorkaround) {
-                    activity.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+                if (ToBackCompositorHelper.shouldTransparentizeWebViewParent() && webViewParent != null) {
+                    webViewParent.setBackgroundColor(ToBackCompositorHelper.resolveWebViewBackgroundColor());
                 }
-                if (webViewParent != null && fullStackWorkaround) {
-                    webViewParent.setBackgroundColor(Color.TRANSPARENT);
-                }
-                webView.setBackgroundColor(isMiuiDevice() ? Color.argb(1, 255, 255, 255) : Color.TRANSPARENT);
-                webView.setAlpha(isMiuiDevice() ? 0.99f : (originalWebViewAlpha != null ? originalWebViewAlpha : 1f));
+                webView.setBackgroundColor(ToBackCompositorHelper.resolveWebViewBackgroundColor());
+                webView.setLayerType(ToBackCompositorHelper.resolveWebViewLayerType(), null);
+                float alpha = ToBackCompositorHelper.resolveWebViewAlpha(originalWebViewAlpha != null ? originalWebViewAlpha : 1f);
+                webView.setAlpha(alpha);
                 if (webViewParent != null) {
                     webViewParent.requestTransparentRegion(webView);
                 }
@@ -2167,20 +2018,14 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             }
         };
 
-        activity.runOnUiThread(() -> {
-            apply.run();
-            if (isMiuiDevice()) {
-                webView.postDelayed(apply, 50);
-                webView.postDelayed(apply, 250);
-            }
-        });
+        activity.runOnUiThread(apply);
     }
 
     private void applyTransparentBackgroundsForToBack() {
         if (!isToBackMode()) {
             return;
         }
-        activateTransparentBackgroundsForToBack(cameraXView);
+        applyToBackVisualState(cameraXView);
     }
 
     private void restoreWebViewVisualState() {
@@ -2227,6 +2072,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 } else {
                     webView.setBackgroundColor(DEFAULT_WEB_VIEW_BACKGROUND);
                 }
+                webView.setLayerType(View.LAYER_TYPE_NONE, null);
                 if (webViewParent != null && parentBackgroundCaptured) {
                     webViewParent.setBackground(parentBackground);
                 }
@@ -2237,14 +2083,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     @Override
     public void onCameraStarted(int width, int height, int x, int y) {
         cameraRestartAfterResumeInProgress = false;
-        // Always transition window and WebView backgrounds to transparent when the camera starts,
-        // regardless of whether there is a pending JS call. This is critical for the
-        // background/foreground resume cycle: on resume, handleOnResume() sets backgrounds to
-        // black (to prevent flicker) and then restarts the camera session, but
-        // cameraStartCallbackId is null at that point. Without this unconditional block the
-        // window and WebView stay black after every background/foreground transition.
-        // Both backgrounds are set together in the same UI thread operation to avoid race
-        // conditions and compositor layering issues.
+        // Re-apply WebView transparency after the preview is bound (idempotent safety net for resume).
         applyTransparentBackgroundsForToBack();
 
         PluginCall call = bridge.getSavedCall(cameraStartCallbackId);
@@ -2503,9 +2342,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             resetPendingStartBarcodeScanner();
         }
 
-        restoreOriginalWindowBackground(getBridge().getActivity());
         restoreWebViewVisualState();
-        restoreSystemUiForToBackMode(getBridge().getActivity());
     }
 
     @PluginMethod

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraPreview.java
@@ -154,6 +154,7 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
     private Drawable originalWebViewBackground;
     private boolean originalWebViewBackgroundCaptured = false;
     private Float originalWebViewAlpha;
+    private Integer originalWebViewLayerType;
     private Drawable originalWebViewParentBackground;
     private boolean originalWebViewParentBackgroundCaptured = false;
     private volatile boolean toBackVisualStateActive = false;
@@ -1980,6 +1981,9 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
             if (originalWebViewAlpha == null) {
                 originalWebViewAlpha = webView.getAlpha();
             }
+            if (originalWebViewLayerType == null) {
+                originalWebViewLayerType = webView.getLayerType();
+            }
             if (webViewParent != null && !originalWebViewParentBackgroundCaptured) {
                 originalWebViewParentBackground = webViewParent.getBackground();
                 originalWebViewParentBackgroundCaptured = true;
@@ -2036,24 +2040,27 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
         Activity activity = getActivity();
         WebView webView = getBridge().getWebView();
         final Float alphaToRestore;
+        final Integer layerTypeToRestore;
         final Drawable webViewBackground;
         final boolean webViewBackgroundCaptured;
         final Drawable parentBackground;
         final boolean parentBackgroundCaptured;
         synchronized (this) {
             alphaToRestore = originalWebViewAlpha;
+            layerTypeToRestore = originalWebViewLayerType;
             webViewBackground = originalWebViewBackground;
             webViewBackgroundCaptured = originalWebViewBackgroundCaptured;
             parentBackground = originalWebViewParentBackground;
             parentBackgroundCaptured = originalWebViewParentBackgroundCaptured;
             originalWebViewAlpha = null;
+            originalWebViewLayerType = null;
             originalWebViewBackground = null;
             originalWebViewBackgroundCaptured = false;
             originalWebViewParentBackground = null;
             originalWebViewParentBackgroundCaptured = false;
         }
 
-        if (alphaToRestore == null && !webViewBackgroundCaptured && !parentBackgroundCaptured) {
+        if (alphaToRestore == null && layerTypeToRestore == null && !webViewBackgroundCaptured && !parentBackgroundCaptured) {
             return;
         }
 
@@ -2072,7 +2079,9 @@ public class CameraPreview extends Plugin implements CameraXView.CameraXViewList
                 } else {
                     webView.setBackgroundColor(DEFAULT_WEB_VIEW_BACKGROUND);
                 }
-                webView.setLayerType(View.LAYER_TYPE_NONE, null);
+                if (layerTypeToRestore != null) {
+                    webView.setLayerType(layerTypeToRestore, null);
+                }
                 if (webViewParent != null && parentBackgroundCaptured) {
                     webViewParent.setBackground(parentBackground);
                 }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/CameraXView.java
@@ -739,7 +739,12 @@ public class CameraXView implements LifecycleOwner, LifecycleObserver {
         previewContainer.setFocusable(true);
 
         // Disable any potential drawing artifacts that might cause 1px offset
-        previewContainer.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+        boolean toBack = sessionConfig != null && sessionConfig.isToBack();
+        if (ToBackCompositorHelper.shouldUseHardwareLayerOnPreviewContainer(toBack)) {
+            previewContainer.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+        } else {
+            previewContainer.setLayerType(View.LAYER_TYPE_NONE, null);
+        }
 
         // Ensure no clip bounds that might cause visual offset
         previewContainer.setClipChildren(false);

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelper.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelper.java
@@ -14,14 +14,6 @@ public final class ToBackCompositorHelper {
 
     private ToBackCompositorHelper() {}
 
-    public static boolean shouldModifyWindowBackground() {
-        return false;
-    }
-
-    public static boolean shouldLockSystemUiColors() {
-        return false;
-    }
-
     public static boolean shouldTransparentizeWebViewParent() {
         return true;
     }

--- a/android/src/main/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelper.java
+++ b/android/src/main/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelper.java
@@ -1,0 +1,44 @@
+package app.capgo.capacitor.camera.preview;
+
+import android.graphics.Color;
+import android.view.View;
+
+/**
+ * Policy for Android {@code toBack} compositing.
+ * <p>
+ * Camera preview sits behind the Capacitor WebView. Only the WebView stack should be made
+ * transparent — never the Activity window drawable or system bar colors. Touching those causes
+ * status/navigation bar flicker (Pixel/Android 16) and fights edge-to-edge scrims.
+ */
+public final class ToBackCompositorHelper {
+
+    private ToBackCompositorHelper() {}
+
+    public static boolean shouldModifyWindowBackground() {
+        return false;
+    }
+
+    public static boolean shouldLockSystemUiColors() {
+        return false;
+    }
+
+    public static boolean shouldTransparentizeWebViewParent() {
+        return true;
+    }
+
+    public static int resolveWebViewBackgroundColor() {
+        return Color.TRANSPARENT;
+    }
+
+    public static float resolveWebViewAlpha(float originalAlpha) {
+        return originalAlpha;
+    }
+
+    public static boolean shouldUseHardwareLayerOnPreviewContainer(boolean toBack) {
+        return !toBack;
+    }
+
+    public static int resolveWebViewLayerType() {
+        return View.LAYER_TYPE_HARDWARE;
+    }
+}

--- a/android/src/test/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelperTest.java
+++ b/android/src/test/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelperTest.java
@@ -1,0 +1,49 @@
+package app.capgo.capacitor.camera.preview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.graphics.Color;
+import android.view.View;
+import org.junit.Test;
+
+public class ToBackCompositorHelperTest {
+
+    @Test
+    public void neverModifiesWindowBackground() {
+        assertFalse(ToBackCompositorHelper.shouldModifyWindowBackground());
+    }
+
+    @Test
+    public void neverLocksSystemUiColors() {
+        assertFalse(ToBackCompositorHelper.shouldLockSystemUiColors());
+    }
+
+    @Test
+    public void transparentizesWebViewParentOnAllDevices() {
+        assertTrue(ToBackCompositorHelper.shouldTransparentizeWebViewParent());
+    }
+
+    @Test
+    public void webViewBackgroundIsFullyTransparent() {
+        assertEquals(Color.TRANSPARENT, ToBackCompositorHelper.resolveWebViewBackgroundColor());
+    }
+
+    @Test
+    public void preservesOriginalWebViewAlpha() {
+        assertEquals(0.75f, ToBackCompositorHelper.resolveWebViewAlpha(0.75f), 0.0001f);
+        assertEquals(1f, ToBackCompositorHelper.resolveWebViewAlpha(1f), 0.0001f);
+    }
+
+    @Test
+    public void skipsHardwareLayerOnPreviewContainerWhenToBack() {
+        assertFalse(ToBackCompositorHelper.shouldUseHardwareLayerOnPreviewContainer(true));
+        assertTrue(ToBackCompositorHelper.shouldUseHardwareLayerOnPreviewContainer(false));
+    }
+
+    @Test
+    public void usesHardwareLayerForWebViewTransparency() {
+        assertEquals(View.LAYER_TYPE_HARDWARE, ToBackCompositorHelper.resolveWebViewLayerType());
+    }
+}

--- a/android/src/test/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelperTest.java
+++ b/android/src/test/java/app/capgo/capacitor/camera/preview/ToBackCompositorHelperTest.java
@@ -11,16 +11,6 @@ import org.junit.Test;
 public class ToBackCompositorHelperTest {
 
     @Test
-    public void neverModifiesWindowBackground() {
-        assertFalse(ToBackCompositorHelper.shouldModifyWindowBackground());
-    }
-
-    @Test
-    public void neverLocksSystemUiColors() {
-        assertFalse(ToBackCompositorHelper.shouldLockSystemUiColors());
-    }
-
-    @Test
     public void transparentizesWebViewParentOnAllDevices() {
         assertTrue(ToBackCompositorHelper.shouldTransparentizeWebViewParent());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Replace OEM-specific `toBack` transparency hacks with a single compositor policy in `ToBackCompositorHelper`
- Stop modifying the Activity window drawable and system bar colors in `toBack` mode
- Transparentize the WebView **and its parent** immediately on start, resume, and screen unlock (not deferred to `onCameraStarted`)
- Skip hardware compositor isolation on the preview container when `toBack: true`
- Add unit tests for the helper policy

Fixes #335
Fixes #331
Fixes #298

## Why
All three reopened issues stem from how Android composites the camera preview behind the Capacitor WebView:

| Issue | Symptom | Root cause in prior code |
|-------|---------|--------------------------|
| #335 | Pixel 9 status/nav bar flicker | `window.setBackgroundDrawable(TRANSPARENT)` and `lockSystemUiForToBackMode()` fight edge-to-edge scrim recalculation |
| #331 | Black preview (Xiaomi, Samsung, Moto) | Parent transparency was gated to MIUI/Huawei only; MIUI `alpha=0.99` hack still leaves opaque compositor on affected devices |
| #298 | Resume black/white flicker, stuck UI | Non-MIUI path only *captured* state on resume (`prepare…`) and waited for `onCameraStarted` to apply transparency, leaving an opaque WebView gap during camera rebind; `handleScreenUnlocked` skipped transparency entirely |

### Why #332 and #336 were insufficient
- **#332** added MIUI-only `alpha=0.99` / near-white background and limited full-stack transparency to MIUI/Huawei. Users on Samsung, Moto, and newer Xiaomi still reported black preview because their WebView parent stayed opaque.
- **#336** tried to stop bar flicker by forcing opaque status/navigation bar colors. On Pixel/Android 16 this still flickers because the underlying problem is touching window-level drawables and fighting the system compositor — not missing bar color locks.

## How
- Introduced `ToBackCompositorHelper` with explicit, testable rules:
  - **Never** modify `Activity` window background or system UI colors
  - **Always** transparentize WebView + parent (all OEMs)
  - Use `LAYER_TYPE_HARDWARE` on the WebView (required for Chromium alpha holes)
  - **Do not** force `LAYER_TYPE_HARDWARE` on the preview container in `toBack` mode (prevents compositor isolation that hides the camera feed)
- Collapsed `prepare…` / `activate…` / OEM branches into one idempotent `applyToBackVisualState()` called from `start`, `handleOnResume`, `handleScreenUnlocked`, and `onCameraStarted`
- Removed MIUI `alpha=0.99` hack, delayed re-apply posts, and `lockSystemUiForToBackMode`

## Testing
- `bun run verify:android` — clean build + unit tests pass (includes new `ToBackCompositorHelperTest`)
- `bun run verify:web` — TypeScript build passes
- `bun run lint` / `bun run fmt` — pass
- iOS `verify:ios` not run locally (no macOS/Xcode in cloud agent VM); no iOS files changed

## Not Tested
- Physical device validation on Pixel 9, Samsung A16, Xiaomi 14T Pro, Moto g85 (requires reporter hardware)
- `toBack: false` regression on device (code path unchanged except shared preview-container layer-type guard)
- iOS build (unchanged platform code; CI should cover)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dbdb323-aff7-4291-94b6-3de5154bd260?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dbdb323-aff7-4291-94b6-3de5154bd260&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-camera-preview/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217473&installation_model_id=430928&pr_number=397&repository=Cap-go%2Fcapacitor-camera-preview&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-camera-preview%2Fpull%2F397&signature=0b68ea03d5b52ba46c99c05f696601ed9cda04f88ad3e2aa94efa1122bd26d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-camera-preview/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

